### PR TITLE
Version 3 of the Infidel Sensor

### DIFF
--- a/firmware/Host_ee_prog.ino
+++ b/firmware/Host_ee_prog.ino
@@ -1,11 +1,11 @@
 /*  Firmware for the Host for the (SS495) hall-sensor based filament diameter sensor.
     Reads and send I2C and show Values, 
 
-    Built for Arduino Uno oder Mega
+    Built for Arduino Uno or Mega
 
     Licensed CC-0 / Public Domain 
 
-    by Michael Doppler (midopple)
+    Revised by Michael Doppler (midopple)    
 */
 
 

--- a/firmware/Host_ee_prog.ino
+++ b/firmware/Host_ee_prog.ino
@@ -363,7 +363,10 @@ void get_value_from_uart(){
       Wire.write(b4);             // sends value byte  
       Wire.endTransmission();     // stop transmitting
 
-      Serial.println(F("Set Value for Table"));
+      Wire.requestFrom(INFIDELADD, 1);
+      b1 = Wire.read();
+
+      Serial.print(F("Set Value for Table. Ack: "));Serial.println(b1,DEC);
     }
     else{
       Serial.println(F("Wrong Value for ADC or DIA"));
@@ -384,7 +387,10 @@ void get_value_from_uart(){
     Wire.write(b4);             // sends value byte  
     Wire.endTransmission();     // stop transmitting
 
-    Serial.println(F("Set Value for DAC Values"));
+    Wire.requestFrom(INFIDELADD, 1);
+    b1 = Wire.read();
+
+    Serial.print(F("Set Value for DAC Values. Ack: "));Serial.println(b1,DEC);
   }
   else{
     Serial.println(F("Wrong Value for IDX 0-5 or 9"));

--- a/firmware/Infidel_release_ee.ino
+++ b/firmware/Infidel_release_ee.ino
@@ -209,6 +209,7 @@ void requestISR() {
       TinyWireS.write(MAIN_VERSION);
       TinyWireS.write(VERSION_I2C);
     break;
+    //Response that DAC Override is active
     case I2C_CMD_OVERRIDE_DAC:
        TinyWireS.write(DAC_override_active);
     break;
@@ -228,7 +229,9 @@ void requestISR() {
       TinyWireS.write(b2);
       TinyWireS.write(b3);
       TinyWireS.write(b4);
-    
+    break;
+    case I2C_CMD_SET_TAB:
+       TinyWireS.write(1);
     break;
   }
 }
@@ -283,6 +286,9 @@ void receiveISR(uint8_t num_bytes) {
 
       break;
       case I2C_CMD_SET_TAB:
+        
+        I2C_akt_cmd = I2C_CMD_SET_TAB;
+        
         uint8_t idx = TinyWireS.read();
         b1 = TinyWireS.read();
         b2 = TinyWireS.read();

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -52,15 +52,23 @@ Program the Host with Host_ee_prog.ino and start the console with 19200 baudrate
 
 On start, the following is shown:
 ```sh
-Version: 1.11
+Infidel Sensor Programmer
+Scanning...
+I2C device found at address 43 
+ 
+Version: 3.12
 Table [ADC] [DIA in um]:
-00: 0001 / 2999
-01: 0617 / 2092
-02: 0722 / 1711
-03: 0816 / 1401
-04: 0999 / 1001
-05: 1022 / 0001
-Command Input (0 - val / 1 - RAW val / 2 - Version / 3 - Table / 4 - Set Table Val / 5 - Ongoing raw read / 6 - sample Mean ADC Val ):
+00: 0000 / 3000
+01: 0619 / 2090
+02: 0702 / 1700
+03: 0817 / 1400
+04: 1000 / 1000
+05: 1023 / 0000
+Table [DAC min Uout in uV] [DAC max Uout in uV]:
+09: 1344 / 2017
+Command Input 0 - val / 1 - RAW val / 2 - Version / 3 - Table / 4 - Set Tabel Val / 5 - Ongoing raw read / 6 - sample Mean ADC Val
+Command Input 7 - DAC 0 PWW / 8 - DAC 255 PWM
+
 ```
 
 | Commands | Note |  Output |

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -71,14 +71,18 @@ Command Input (0 - val / 1 - RAW val / 2 - Version / 3 - Table / 4 - Set Table V
 | 3 | Read the Diameter Table | Table [idx] [ADC] [DIA in um] |
 | 4 | Set the Value in the Table | Input values for Table [IDX],[ADC],[DIA um] like (1,619,2090) |
 | 5 | Ongoing reading the ADC raw Value, stop when the command 5 is sent one more time | 
-| 6 | Read Meanvalue from Sensor (100 Samples), Display Min / Max / Mean / cnt, used it for Calibration |
+| 6 | Read Meanvalue from Sensor (100 Samples), Display Min / Max / Mean / cnt, used it for Calibration | ADC Mean: 704 / Min: 688 / Max: 713 / Cnt: 100 |
+| 7 | Set DAC to PWM 0 --> for check Output Voltage at LOW |
+| 8 | Set DAC to PWM 255 --> for check Output Voltage at HIGH |
 | h | Show the command list |
 
 ## Calibration
 
-Start with the bigger shaft of known diameter (e.g., 2 mm), insert it into the sensor and read the raw ADC value with command "2".
+Start with the bigger shaft of known diameter (e.g., 2 mm), insert it into the sensor and read the raw ADC value with command "6".
+Command "6" determines the mean value over 100 measurements and removes the outliers
+
 ```sh
-Diameter [mm] / [ADC]: 2.12 / RAW: 503
+ADC Mean: 704 / Min: 688 / Max: 713 / Cnt: 100
 ```
 Note the ADC value and use the command "4".
 The console should show:
@@ -135,6 +139,18 @@ The sensor sends an analog signal to Pin 5 [OUT].
 The range goes from 1.42 VDC to 2.14 VDC .
 The voltage is the analog for the diameter: 1.73V is equal to 1.73mm diameter.
 
+## Calibrate the Analog Output
+
+Connect a Multimeter to GND and OUT.
+
+* Set with the command "7" the PWM to LOW, meassure the Voltage on Analog OUT and note it (like 1,344 V)
+* Set with the command "8" the PWM to HIGH, meassure the Voltage on Analog OUT and note it (like 2,017 V)
+
+Set with the command "4" the table Value for Index 9 (Calibration Values for DAC)
+IDX 9 then LOW Volate and the HIGH Voltage --> like: 9,1344,2017
+
+Check the table with command "3".
+The Values are stored en the EEPROM for the next Start
 
 ## Fault Pin
 

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -109,6 +109,25 @@ The values are stored in the EEPROM and will load from the EEPROM at the next po
 
 If you program the sensor with a new firmware over the ISP the EEPROM will be erased and the sensor will start with default settings.
  
+## Calibration with Button (Standalone)
+
+Press the Button at Powerup for 3 sec, if the Calibrationmode start the LED flashes 10 times
+The sensor sends an analog signal to Pin 5 [OUT].
+
+* Step 1, Led Flash 1 Times
+	*   Insert Drill with 1,4mm
+	*   Wait a short Time, 1-2 sec
+	*   Press the Button for 1 sec
+	*   The Led light for 2 sec, the Sensor is getting 100 Samples from the ADC 
+	*   If the messure is Ok the Led flash fast
+	*   Remove the drill an press the Button
+*   Step 2 Led flashes 2 Times (1,7mm Drill)
+    *   Insert the Drill 1,7mm and repeat Step 1
+*   Step 3, Led flash 3 times (2mm Drill)
+	*   Insert the Drill with 2mm and repeat Step 1
+
+The Calibration is done
+
 ## Analog Output
  
 The sensor sends an analog signal to Pin 5 [OUT].

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -60,7 +60,7 @@ Table [ADC] [DIA in um]:
 03: 0816 / 1401
 04: 0999 / 1001
 05: 1022 / 0001
-Command Input (0 - val / 1 - RAW val / 2 - Version / 3 - Table / 4 - Set Table Val / 5 - Ongoing raw read):
+Command Input (0 - val / 1 - RAW val / 2 - Version / 3 - Table / 4 - Set Table Val / 5 - Ongoing raw read / 6 - sample Mean ADC Val ):
 ```
 
 | Commands | Note |  Output |
@@ -71,6 +71,7 @@ Command Input (0 - val / 1 - RAW val / 2 - Version / 3 - Table / 4 - Set Table V
 | 3 | Read the Diameter Table | Table [idx] [ADC] [DIA in um] |
 | 4 | Set the Value in the Table | Input values for Table [IDX],[ADC],[DIA um] like (1,619,2090) |
 | 5 | Ongoing reading the ADC raw Value, stop when the command 5 is sent one more time | 
+| 6 | Read Meanvalue from Sensor (100 Samples), Display Min / Max / Mean / cnt, used it for Calibration |
 | h | Show the command list |
 
 ## Calibration

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -142,15 +142,17 @@ The voltage is the analog for the diameter: 1.73V is equal to 1.73mm diameter.
 ## Calibrate the Analog Output
 
 Connect a Multimeter to GND and OUT.
+The Analog Output depend on the VCC Voltage, so make the Calibration when the Sensor is connected to the Printerboard
+and not to the unstable USB Port.
 
 * Set with the command "7" the PWM to LOW, meassure the Voltage on Analog OUT and note it (like 1,344 V)
 * Set with the command "8" the PWM to HIGH, meassure the Voltage on Analog OUT and note it (like 2,017 V)
 
 Set with the command "4" the table Value for Index 9 (Calibration Values for DAC)
-IDX 9 then LOW Volate and the HIGH Voltage --> like: 9,1344,2017
+IDX 9 then LOW Voltage and the HIGH Voltage --> like: 9,1344,2017
 
 Check the table with command "3".
-The Values are stored en the EEPROM for the next Start
+The Values are stored in the EEPROM for the next Start
 
 ## Fault Pin
 


### PR DESCRIPTION

New functions and updates:

- Command "6" reads the average value of the ADC input (sensor) over 100 samples, removes the outliers and sends the AVERAGE/MIN/MAX values.
Results in better accuracy when calibrating.

- Calibration without host, if the button is pressed when switching on, the calibration starts at the sensor.
The calibration procedure is described in the readme.me file.

- Command "7" sets the analogue output to PWM 0.
- Command "8" sets the analogue output to PWM 255 (MAX).
This is necessary to calibrate the analogue output because it depends on the supply voltage. Therefore, do this only when the sensor is connected to the printer control.

- The calibration table contains the calibration values for the DAC with index 9, the procedure is described in the readme.me.
The values for the DAC can be set via OK command "4".
