### PR TITLE
fix: Corrects link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The main idea is to use the sensor to correct for filament diameter deviations w
 
 Based on this proof-of-concept: https://www.youmagine.com/designs/filament-diameter-sensor
 
-Detailed documention for InFiDEL: https://drspangle.github.io/infidel-sensor/
+Detailed documention for InFiDEL: https://infidel-sensor.readthedocs.io/
 
 ## Assembly and Setup
 [![Assembly and Setup Instructions on Youtube](https://img.youtube.com/vi/RYgdLPe_T0c/0.jpg)](https://www.youtube.com/watch?v=RYgdLPe_T0c)


### PR DESCRIPTION
Link now points to the readthedocs link https://infidel-sensor.readthedocs.io/, would resolve https://github.com/drspangle/infidel-sensor/issues/60